### PR TITLE
GCC 15 compatibility

### DIFF
--- a/src/build.sh.in
+++ b/src/build.sh.in
@@ -10,6 +10,7 @@ sed \
   -e 's/\(gmp_compile="$CC .*conftest.c\)/\1 $LIBS/g' \
   configure > configure.tmp
 mv configure.tmp configure
+patch -p1 configure ../gcc.15.patch
 chmod +x configure
 
 if [ "$5" = "false" ]; then

--- a/src/dune
+++ b/src/dune
@@ -13,7 +13,7 @@
 
 (rule
  (targets gmp.h libgmp.a dllgmp.so)
- (deps gmp-6.3.0.tar.xz libgmp-fat.patch build.sh)
+ (deps gmp-6.3.0.tar.xz libgmp-fat.patch build.sh gcc.15.patch)
  (action
   (with-stdout-to
    build.log

--- a/src/gcc.15.patch
+++ b/src/gcc.15.patch
@@ -1,0 +1,11 @@
+--- configure	2025-06-11 15:04:39.201256931 +0200
++++ configure	2025-06-11 15:05:03.966577243 +0200
+@@ -6568,7 +6568,7 @@
+ 
+ #if defined (__GNUC__) && ! defined (__cplusplus)
+ typedef unsigned long long t1;typedef t1*t2;
+-void g(){}
++void g(int, const t1*, t1, t1*, const t1*, int){}
+ void h(){}
+ static __inline__ t1 e(t2 rp,t2 up,int n,t1 v0)
+ {t1 c,x,r;int i;if(v0){c=1;for(i=1;i<n;i++){x=up[i];r=x+1;rp[i]=r;}}return c;}


### PR DESCRIPTION
This the patch in https://github.com/mirage/ocaml-gmp/pull/25 allowing to build `ocaml-gmp` with a recent GCC